### PR TITLE
[FE]認証周りでエラーが出ないようにする

### DIFF
--- a/src/components/layouts/Layout/AdminLayout.tsx
+++ b/src/components/layouts/Layout/AdminLayout.tsx
@@ -7,7 +7,6 @@ type Props = {
 }
 
 export const AdminLayout = ({ children }: Props) => {
-  useAuth();
   return (
     <div className="flex flex-row">
       <AdminSidebar />

--- a/src/components/layouts/SideBar/AdminSideBar/index.tsx
+++ b/src/components/layouts/SideBar/AdminSideBar/index.tsx
@@ -9,6 +9,7 @@ import { IoIosCreate } from "react-icons/io";
 
 export const AdminSidebar = () => {
   const { owner } = useCertainOwner();
+  useAuth();
 
   //SideBarに必要なリンクの配列
   const menuLinks = [

--- a/src/feature/owner/components/SignInForm/index.tsx
+++ b/src/feature/owner/components/SignInForm/index.tsx
@@ -38,7 +38,7 @@ export const SignInForm = (): JSX.Element => {
             });
             const cookies = parseCookies();
             //headerに認証情報を追加する
-            setAuthCookie(data.id)
+            setAuthCookie(cookies.ownerId)
 
             setOwner(data);
             return router.push(Routing.adminRentalHouses.buildRoute().path)

--- a/src/feature/rentalHouse/hooks/useOwnRentalHouses.ts
+++ b/src/feature/rentalHouse/hooks/useOwnRentalHouses.ts
@@ -2,18 +2,14 @@ import { useLoading } from "@/hooks/useLoading";
 import { useEffect, useState } from "react";
 import { RentalHouse } from "../type/rentalHouse";
 import { rentalHoseRepository } from "../modules/rentalHouse.repository";
-import { axiosInstance } from "@/lib/axios";
 
 export const useOwnRentalHouses = () => {
-
   const { showLoading, hideLoading } = useLoading();
   const [ myRentalHouses, setMyRentalHouses ] = useState<RentalHouse[]>([]);
   
   useEffect(() => {
     (async () => {
       showLoading();
-      // リファクタ: 毎回checkを待ってから返す必要がある。
-      if (!axiosInstance.defaults.headers.common["Authorization"]) return
       const fetchedMyRentalHouses = await rentalHoseRepository.getAllOwn();
       setMyRentalHouses(fetchedMyRentalHouses)
       hideLoading();

--- a/src/feature/room/components/AdminRoomListBelongToRentalHose/index.tsx
+++ b/src/feature/room/components/AdminRoomListBelongToRentalHose/index.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export const AdminRoomListBelongToRentalHose = ({ mansionRooms }: Props) => (
   <div className="w-full px-4 grid gap-x-4 gap-y-8  sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-3 ">
-    { !mansionRooms?.mansion_rooms?.length ? (
+    { !mansionRooms?.mansion_rooms ? (
       <p className="text-center font-bold text-red-400">まだ作成していません。</p>
     ) : (
       mansionRooms?.mansion_rooms?.map(({ id, name, mansion_room_photos, stay_fee }) => {

--- a/src/feature/room/hooks/useSpecificRentalHouseAndBelongingToRooms.ts
+++ b/src/feature/room/hooks/useSpecificRentalHouseAndBelongingToRooms.ts
@@ -11,8 +11,6 @@ export const useSpecificRentalHouseAndBelongingToRooms = (houseId?: string) => {
   useEffect(() => {
     if(!houseId) return
     (async () => {
-      // リファクタ: 毎回checkを待ってから返す必要がある。
-      if (!axiosInstance.defaults.headers.common["Authorization"]) return
       showLoading();
       const fetchedRes = await rentalHoseRepository.getRoomsWithSpecificRentalHouse(houseId);
       setSpecificRentalHouseAndBelongingToRooms(fetchedRes)

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -5,7 +5,6 @@ import { parseCookies, setCookie, destroyCookie } from 'nookies';
 import { axiosInstance, setAuthCookie } from "@/lib/axios";
 import { useLoading } from "./useLoading";
 
-// TODO: 最終日までに認証をしっかり書く
 export const useAuth = () => {
   const router = useRouter(); 
   const cookies = parseCookies();

--- a/src/hooks/useLoading.ts
+++ b/src/hooks/useLoading.ts
@@ -7,7 +7,7 @@ import { useRecoilState } from "recoil"
 export const useLoading = () => {
   const [state, setState] = useRecoilState<Loading>(LoadingState);
     const showLoading = useCallback((): void => {
-      setState({ ...state, ... { isLoading: false }});
+      setState({ ...state, ... { isLoading: true }});
     },
     []
   )


### PR DESCRIPTION
## 概要
useAuthを使って認証を管理しているがそのuseAuthがAdminLayoutの中だと呼ばれていないことが原因だった。
完全には理解していないがgetLayoutを使用するとサーバー側でレンダリングされるため処理が走らないのかなという認識

対応策
-> サイドバーで呼ぶことにした。(Adminページでは全てで呼ばれている為)