### PR TITLE
[FE]roomの最低価格がInfintyになる事象の解決

### DIFF
--- a/src/feature/rentalHouse/components/list/components/RentalHouseCard/index.tsx
+++ b/src/feature/rentalHouse/components/list/components/RentalHouseCard/index.tsx
@@ -20,7 +20,7 @@ export const RentalHouseCard = ({
 }: Props): JSX.Element => {
   //1番安い家賃を取得する。
   const minRent = useMemo(
-    () => rooms && Math.min(...rooms.map((room) => room.rent)),
+    () => rooms && rooms?.length > 1 && Math.min(...rooms.map((room) => room.rent)),
     [rooms]
   );
 


### PR DESCRIPTION
### 概要

```
  const minRent = useMemo(
    () => rooms && rooms?.length > 1 && Math.min(...rooms.map((room) => room.rent)),
    [rooms]
  );
```

roomsが存在しても中身がundefindだったり空だった時に事象が発生していたので配列として渡されているかを条件文に追加